### PR TITLE
Updated the pom to set the correct SCM block for git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     <version>1.1.2-SNAPSHOT</version>
 
     <scm>
-        <connection>scm:svn:https://source.jasig.org/portlets/email-preview/trunk</connection>
-        <developerConnection>scm:svn:https://source.jasig.org/portlets/email-preview/trunk</developerConnection>
-        <url>http://developer.jasig.org/source/browse/jasigsvn/portlets/email-preview/trunk</url>
+        <connection>scm:git:git@github.com:Jasig/email-preview.git</connection>
+        <developerConnection>scm:git:git@github.com:Jasig/email-preview.git</developerConnection>
+        <url>scm:git:git@github.com:Jasig/email-preview.git</url>
     </scm>
-
+   
     <properties>
         <spring.version>2.5.6</spring.version>
         <resource-server.version>1.0.12</resource-server.version>


### PR DESCRIPTION
I've updated the pom to set the correct SCM block. Previously it was still pointing at SVN.
