### PR TITLE
EMAILPLT-142

### DIFF
--- a/src/main/java/org/jasig/portlet/emailpreview/MailStoreConfiguration.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/MailStoreConfiguration.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.jasig.portlet.emailpreview.dao.IEmailAccountService;
 import org.jasig.portlet.emailpreview.dao.MailPreferences;
+import org.jasig.portlet.emailpreview.security.IStringEncryptionService;
 
 /**
  * 
@@ -63,7 +64,8 @@ public final class MailStoreConfiguration {
     // Preferences
     private boolean markMessagesAsRead;
     private boolean allowRenderingEmailContent = true;
-    
+    private IStringEncryptionService stringEncryptionService;
+
     public String getProtocol() {
         return protocol;
     }
@@ -200,6 +202,13 @@ public final class MailStoreConfiguration {
         this.usernameSuffix = usernameSuffix;
     }
 
+    public IStringEncryptionService getStringEncryptionService() {
+        return stringEncryptionService;
+    }
+
+    public void setStringEncryptionService(IStringEncryptionService stringEncryptionService) {
+        this.stringEncryptionService = stringEncryptionService;
+    }
     
     public boolean isReadOnly(PortletRequest req, MailPreferences mp) {
         PortletPreferences prefs = req.getPreferences();
@@ -217,6 +226,14 @@ public final class MailStoreConfiguration {
         // class interactions.  Something to work in on refactoring.
     }
 
+    public boolean isUsingDefaultEncryptionKey() {
+        if (stringEncryptionService != null) {
+            return stringEncryptionService.usingDefaultEncryptionKey();
+        } else {
+        	return false;
+        }
+    }
+    
     /**
      * @see java.lang.Object#equals(Object)
      */

--- a/src/main/java/org/jasig/portlet/emailpreview/mvc/MailStoreConfigurationForm.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/mvc/MailStoreConfigurationForm.java
@@ -52,6 +52,7 @@ public class MailStoreConfigurationForm implements Serializable {
     private String authenticationServiceKey;
     private List<String> allowableAuthenticationServiceKeys = Collections.emptyList();
     private String usernameSuffix;
+    private Boolean isUsingDefaultEncryptionKey;
 
     @SuppressWarnings("unchecked")
     private Map<String, Attribute> additionalProperties = LazyMap.decorate(
@@ -78,6 +79,7 @@ public class MailStoreConfigurationForm implements Serializable {
         form.setAllowRenderingEmailContent(config.getAllowRenderingEmailContent());
         form.setExchangeDomain(config.getExchangeDomain());
         form.setExchangeAutodiscover(config.isExchangeAutodiscover());
+        form.setIsUsingDefaultEncryptionKey(config.isUsingDefaultEncryptionKey());
         
         for (Map.Entry<String, String> entry : config.getJavaMailProperties().entrySet()) {
             form.getJavaMailProperties().put(entry.getKey(), new Attribute(entry.getValue()));
@@ -223,4 +225,12 @@ public class MailStoreConfigurationForm implements Serializable {
     public void setExchangeAutodiscover(Boolean exchangeAutodiscover) {
         this.exchangeAutodiscover = exchangeAutodiscover;
     }
+
+	public Boolean getIsUsingDefaultEncryptionKey() {
+		return isUsingDefaultEncryptionKey;
+	}
+
+	public void setIsUsingDefaultEncryptionKey(Boolean isUsingDefaultEncryptionKey) {
+		this.isUsingDefaultEncryptionKey = isUsingDefaultEncryptionKey;
+	}
 }

--- a/src/main/java/org/jasig/portlet/emailpreview/security/IStringEncryptionService.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/security/IStringEncryptionService.java
@@ -27,23 +27,29 @@ package org.jasig.portlet.emailpreview.security;
  * @author bourey
  */
 public interface IStringEncryptionService {
-	
-	/**
-	 * Encrypt a string
-	 * 
-	 * @param plaintext
-	 * @return encrypted version of the plaintext
-	 * @throws StringEncryptionException
-	 */
-	public String encrypt(String plaintext);
-	
-	/**
-	 * Decrypt a string
-	 * 
-	 * @param cryptotext
-	 * @return decrypted version of the cryptotext
-	 * @throws StringEncryptionException
-	 */
-	public String decrypt(String cryptotext);
+    
+    /**
+     * Encrypt a string
+     * 
+     * @param plaintext
+     * @return encrypted version of the plaintext
+     * @throws StringEncryptionException
+     */
+    public String encrypt(String plaintext);
+    
+    /**
+     * Decrypt a string
+     * 
+     * @param cryptotext
+     * @return decrypted version of the cryptotext
+     * @throws StringEncryptionException
+     */
+    public String decrypt(String cryptotext);
+
+    /**
+     * Returns true if the encryptor is configured to use the default encryption key.
+     * @return true if encryption key is default value
+     */
+    public boolean usingDefaultEncryptionKey();
 
 }

--- a/src/main/java/org/jasig/portlet/emailpreview/service/SimpleServiceBroker.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/service/SimpleServiceBroker.java
@@ -85,6 +85,7 @@ public class SimpleServiceBroker implements IServiceBroker {
 
         config.setExchangeDomain(prefs.getValue(MailPreferences.EXCHANGE_USER_DOMAIN.getKey(), null));
         config.setExchangeAutodiscover(Boolean.valueOf(prefs.getValue(MailPreferences.EXCHANGE_AUTODISCOVER.getKey(), "false")));
+        config.setStringEncryptionService(stringEncryptionService);
         
         // set the port number
         try {

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -39,3 +39,4 @@ cas-config.casServerUrl=http://localhost:8080/cas
 # CAS imap/pop serviceUrl used in the Proxy CAS configuration on the imap/pop server side
 cas-config.serviceUrl=imap://mail.jasig.org
 
+encryption.salt=changeMe

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -85,6 +85,8 @@ editPreferences.preferences.markMessagesAsRead.tooltip=Should messages be marked
 editPreferences.buttonGroup.saveSettings=Save Settings
 editPreferences.buttonGroup.cancel=cancel
 
+editPreferences.warning.message.default.password.set=Encryption key at default value.  Change it in configuration.properties for improved security!
+
 ## error.jsp
 error.message.refresh=Refresh
 error.message.first=ERROR! - Unable to retrieve information from your email account!

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -133,10 +133,8 @@
 
          NOTE:  Read carefully the instructions for the 'stringEncryptionService' bean (below).
     -->
-    <!--
     <bean id="portletPreferencesCredentialsAuthenticationService" 
             class="org.jasig.portlet.emailpreview.service.auth.pp.PortletPreferencesCredentialsAuthenticationService"/>
-    -->
 
     <!-- Before using the string encryption service you MUST first set a password.
 
@@ -144,15 +142,12 @@
          their credentials into the portlet configuration. The system
          won't be able to decrypt them, and users will get an error.
     -->
-    <!--
     <bean id="stringEncryptionService" class="org.jasig.portlet.emailpreview.security.JasyptPBEStringEncryptionServiceImpl">
         <property name="stringEncryptor">
             <bean class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
-                 <property name="password" value=""/>
+                 <property name="password" value="${encryption.salt}"/>
             </bean>
         </property>
     </bean>
-    -->
-
 </beans>
 

--- a/src/main/webapp/WEB-INF/jsp/config.jsp
+++ b/src/main/webapp/WEB-INF/jsp/config.jsp
@@ -40,7 +40,13 @@
     <div class="fl-widget-content portlet-body" role="main">
 
         <form:form action="${ formUrl }" method="POST" commandName="form" htmlEscape="false">
-    
+            <!--  Used for warning that the encryption key hasn't been changed from the default -->
+            <form:input path="isUsingDefaultEncryptionKey" type="hidden" />
+            <c:if test="${form.isUsingDefaultEncryptionKey eq true}">
+                <div class="portlet-msg-error portlet-msg error" role="alert">
+                    <spring:message code="editPreferences.warning.message.default.password.set"/>
+                </div>
+            </c:if>
             <!-- General Configuration Section -->
             <div class="portlet-section" role="region">
                 <h3 class="portlet-section-header" role="heading"><spring:message code="config.preferences.basic"/></h3>


### PR DESCRIPTION
- Enable bean portletPreferencesCredentialsAuthenticationService by default in applicationContext.xml.
- Enhance JasyptPBEStringEncryptionServiceImpl to detect when encryption key is at default value and log ERROR message to logs on portlet initialization
- Enhance portlet manager's email preview portlet rich configuration to display a warning when encryption key is at default value
