### PR TITLE
EMAILPLT-148:

### DIFF
--- a/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
@@ -49,6 +49,8 @@ public class EmailMessage {
     private final EmailMessageContent content;  // Optional;  passed in separately AntiSamy treatment
     private final String toRecipients;
     private final String ccRecipients;
+    private final String bccRecipients;
+
 
 	/*
 	 * Public API.
@@ -60,8 +62,9 @@ public class EmailMessage {
      */
     public EmailMessage(int messageNumber, String uid, String sender, String subject,
                 Date sentDate, boolean unread, boolean answered, boolean deleted, 
-                boolean multipart, String contentType, EmailMessageContent content, String toRecipients, String ccRecipients) {
-	    	    
+                boolean multipart, String contentType, EmailMessageContent content, 
+                String toRecipients, String ccRecipients, String bccRecipients) {
+
 	    // Instance Members.
         this.messageNumber = messageNumber;
         this.uid = uid;  // NB:  may be null
@@ -76,13 +79,13 @@ public class EmailMessage {
         this.content = content;
         this.toRecipients = toRecipients;
         this.ccRecipients = ccRecipients;
-	    
+        this.bccRecipients = bccRecipients;
 	}
 
     public EmailMessage(int messageNumber, String uid, String sender, String subject,
                         Date sentDate, boolean unread, boolean answered, boolean deleted,
                         boolean multipart, String contentType, EmailMessageContent content) {
-        this(messageNumber,uid,sender,subject,sentDate,unread,answered,deleted,multipart,contentType,content,null,null);
+        this(messageNumber,uid,sender,subject,sentDate,unread,answered,deleted,multipart,contentType,content,null,null,null);
     }
 
 	public int getMessageNumber() {
@@ -133,7 +136,13 @@ public class EmailMessage {
 	}
 
     public String getSenderName() {
-        return getSender().split("\\s*<")[0];
+        String senderName = getSender();
+        if (getSender().contains("&lt;")) {
+            senderName = getSender().split("\\s*&lt;")[0];
+        } else if (getSender().contains("<")) {
+            senderName = getSender().split("\\s*<")[0];
+        }
+        return senderName;
     }
 
     /**
@@ -178,11 +187,16 @@ public class EmailMessage {
         return content;
     }
 
-    public String getToRecipients() {
-    	return toRecipients;
-    }
-    
-    public String getCcRecipients() {
-       	return ccRecipients;
-    }
+	public String getToRecipients() {
+		return toRecipients;
+	}
+
+	public String getCcRecipients() {
+		return ccRecipients;
+	}
+
+	public String getBccRecipients() {
+		return bccRecipients;
+	}
+
 }

--- a/src/main/java/org/jasig/portlet/emailpreview/ExchangeEmailMessage.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/ExchangeEmailMessage.java
@@ -34,9 +34,8 @@ public class ExchangeEmailMessage extends EmailMessage {
 
     public ExchangeEmailMessage(int messageNumber, String uid, String exchangeChangeKey, String sender, String subject,
                         Date sentDate, boolean unread, boolean answered, boolean deleted,
-                        boolean multipart, String contentType, EmailMessageContent content, String toRecipients, String ccRecipients) {
-        super(messageNumber, uid, sender, subject, sentDate, unread, answered, deleted,
-                multipart, contentType, content, toRecipients, ccRecipients);
+                        boolean multipart, String contentType, EmailMessageContent content, String to, String cc, String bcc) {
+        super(messageNumber, uid, sender, subject, sentDate, unread, answered, deleted, multipart, contentType, content, to, cc, bcc);
         this.exchangeChangeKey = exchangeChangeKey;
     }
 

--- a/src/main/java/org/jasig/portlet/emailpreview/dao/demo/DemoAccountService.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/dao/demo/DemoAccountService.java
@@ -128,7 +128,9 @@ public final class DemoAccountService implements IEmailAccountService {
                 EmailMessage msg = !m.equals(rslt) ? m
                         : new EmailMessage(m.getMessageNumber(), m.getUid(), m.getSender(), m.getSubject(),
                             m.getSentDate(), false, m.isAnswered(), m.isDeleted(),
-                            m.isMultipart(), m.getContentType(), m.getContent(), m.getToRecipients(), m.getCcRecipients());
+                            m.isMultipart(), m.getContentType(), m.getContent(), m.getToRecipients(),
+                            m.getCcRecipients(), m.getBccRecipients());
+
                 newList.add(msg);
             }
             session.setAttribute(ACCOUNT_SUMMARY_KEY, new AccountSummary(INBOX_URL,
@@ -184,7 +186,9 @@ public final class DemoAccountService implements IEmailAccountService {
             EmailMessage msg = !changed.contains(m.getMessageId()) ? m
                     : new EmailMessage(m.getMessageNumber(), m.getUid(), m.getSender(), m.getSubject(),
                         m.getSentDate(), !seenValue, m.isAnswered(), m.isDeleted(),
-                        m.isMultipart(), m.getContentType(), m.getContent(), m.getToRecipients(), m.getCcRecipients());
+                        m.isMultipart(), m.getContentType(), m.getContent(), m.getToRecipients(),
+                        m.getCcRecipients(), m.getBccRecipients());
+
             newList.add(msg);
         }
 
@@ -222,11 +226,10 @@ public final class DemoAccountService implements IEmailAccountService {
                 EmailMessageContent content = new EmailMessageContent(msg.path("body").getTextValue(), true);
                 String toRecipients = "toTest@test.univ.eu; toTest1@test1.univ.eu";
                 String ccRecipients = "ccTest@test.univ.eu; ccTest1@test1.univ.eu";
-
+                String bccRecipients = "bccTest@test.univ.eu; bccTest1@test1.univ.eu";
                 messages.add(new EmailMessage(messages.size(), uid,
                         sender, subject, sentDate, unread, answered, deleted,
-                        false, "text/plain", content, toRecipients, ccRecipients));
-
+                        false, "text/plain", content, toRecipients, ccRecipients, bccRecipients));
             }
         } catch (Exception e) {
             log.error("Failed to load messages collection", e);

--- a/src/main/java/org/jasig/portlet/emailpreview/dao/exchange/ExchangeAccountDaoImpl.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/dao/exchange/ExchangeAccountDaoImpl.java
@@ -349,7 +349,7 @@ public class ExchangeAccountDaoImpl implements IMailAccountDao<ExchangeFolderDto
                     item.getItemId().getChangeKey(), messageUtils.cleanHTML(from),
                     messageUtils.cleanHTML(item.getSubject()),
                     new Date(item.getDateTimeSent().toGregorianCalendar().getTimeInMillis()),
-                    !item.isIsRead(), answered, deleted, item.isHasAttachments(), contentType, null, null, null);
+                    !item.isIsRead(), answered, deleted, item.isHasAttachments(), contentType, null, null, null, null);
             messages.add(message);
             messageNumber++;
         }
@@ -376,11 +376,15 @@ public class ExchangeAccountDaoImpl implements IMailAccountDao<ExchangeFolderDto
                 BodyTypeType.HTML.equals(message.getBody().getBodyType()));
         String toRecipients = getToRecipients(message);
         String ccRecipients = getCcRecipients(message);
+        String bccRecipients = getBccRecipients(message);
+
 
         ExchangeEmailMessage msg =  new ExchangeEmailMessage(0, message.getItemId().getId(), message.getItemId().getChangeKey(),
                 sender, messageUtils.cleanHTML(message.getSubject()),
                 new Date(message.getDateTimeSent().toGregorianCalendar().getTimeInMillis()),
-                !message.isIsRead(), answered, deleted, message.isHasAttachments(), contentType, content, toRecipients, ccRecipients);
+                !message.isIsRead(), answered, deleted, message.isHasAttachments(), contentType, 
+                content, toRecipients, ccRecipients, bccRecipients);
+
 
         // Insert the changeKey into cache in case the message read status is changed again.
         insertChangeKeyIntoCache(msg.getMessageId(), msg.getExchangeChangeKey());
@@ -388,12 +392,17 @@ public class ExchangeAccountDaoImpl implements IMailAccountDao<ExchangeFolderDto
         return msg;
     }
 
+
     private String getToRecipients(MessageType message) {
         return getRecipients(message.getToRecipients());
     }
     
     private String getCcRecipients(MessageType message) {
         return getRecipients(message.getCcRecipients());
+    }
+    
+    private String getBccRecipients(MessageType message) {
+        return getRecipients(message.getBccRecipients());
     }
 
     private String getRecipients(ArrayOfRecipientsType addrs) {
@@ -422,7 +431,7 @@ public class ExchangeAccountDaoImpl implements IMailAccountDao<ExchangeFolderDto
     }
 
     private String formatEmailAddress(EmailAddressType emailAddr) {
-        return emailAddr.getName() + "<" + emailAddr.getEmailAddress() + ">";
+        return emailAddr.getName() + " &lt;" + emailAddr.getEmailAddress() + "&gt;";
     }
 
     public ItemIdType getMessageChangeKey(String uuid, MailStoreConfiguration config) {

--- a/src/main/java/org/jasig/portlet/emailpreview/dao/javamail/JavamailAccountDaoImpl.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/dao/javamail/JavamailAccountDaoImpl.java
@@ -19,6 +19,7 @@
 package org.jasig.portlet.emailpreview.dao.javamail;
 
 import com.sun.mail.imap.IMAPFolder;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jasig.portlet.emailpreview.AccountSummary;
@@ -53,6 +54,7 @@ import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 import javax.mail.Folder;
 import javax.mail.Message;
+import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.Quota;
@@ -63,6 +65,7 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.util.SharedByteArrayInputStream;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -400,50 +403,9 @@ public final class JavamailAccountDaoImpl implements IMailAccountDao {
         }
 
         Address[] addr = msg.getFrom();
-        String sender = null;
-        if (addr != null && addr.length != 0) {
-            Address a = addr[0];
-            if (INTERNET_ADDRESS_TYPE.equals(a.getType())) {
-                InternetAddress inet = (InternetAddress) a;
-                sender = inet.toUnicodeString();
-            } else {
-                sender = a.toString();
-            }
-        }
+        String sender = getFormattedAddresses(addr);
         Date sentDate = msg.getSentDate();
-        Address[] toRecipients = msg.getRecipients(Message.RecipientType.TO);
-        List <String> toRecipientsList = new ArrayList <String>();
-        String toReceiver = null;
-        String toRecipientsString = null;
-        if (toRecipients != null && toRecipients.length != 0) {
-	        for (Address adress : toRecipients){
-	            if (INTERNET_ADDRESS_TYPE.equals(adress.getType())) {
-	                InternetAddress inet = (InternetAddress) adress;
-	                toReceiver = inet.toUnicodeString();
-	            } else {
-	            	toReceiver = adress.toString();
-	            }      	
-	            toRecipientsList.add(toReceiver);
-	        }
-        }
-        toRecipientsString = StringUtils.join(toRecipientsList, "; ").replaceAll("<","&lt;").replaceAll(">","&gt;");   
 
-        Address[] ccRecipients = msg.getRecipients(Message.RecipientType.CC);
-        List <String> ccRecipientsList = new ArrayList <String>();
-        String ccReceiver = null;
-        String ccRecipientsString = null;
-        if (ccRecipients != null && ccRecipients.length != 0) {
-                for (Address adress : ccRecipients){
-                    if (INTERNET_ADDRESS_TYPE.equals(adress.getType())) {
-                        InternetAddress inet = (InternetAddress) adress;
-                        ccReceiver = inet.toUnicodeString();
-                    } else {
-                        ccReceiver = adress.toString();
-                    }
-                    ccRecipientsList.add(ccReceiver);
-                }
-        }
-        ccRecipientsString = StringUtils.join(ccRecipientsList, "; ").replaceAll("<","&lt;").replaceAll(">","&gt;");      
         boolean unread = !msg.isSet(Flag.SEEN);
         boolean answered = msg.isSet(Flag.ANSWERED);
         boolean deleted = msg.isSet(Flag.DELETED);
@@ -462,10 +424,10 @@ public final class JavamailAccountDaoImpl implements IMailAccountDao {
                         "but the body will not be viewable");
             log.trace(me.getMessage(), me);
         }
-
-        return new EmailMessage(messageNumber, uid, sender, subject, sentDate,
-                unread, answered, deleted, multipart, contentType, msgContent, toRecipientsString, ccRecipientsString);
-
+        String to = getTo(msg);
+        String cc = getCc(msg);
+        String bcc = getBcc(msg);
+        return new EmailMessage(messageNumber, uid, sender, subject, sentDate, unread, answered, deleted, multipart, contentType, msgContent, to, cc, bcc);
     }
 
     /*
@@ -503,9 +465,7 @@ public final class JavamailAccountDaoImpl implements IMailAccountDao {
         }
 
         Collections.reverse(emails);
-
         return emails;
-
     }
 
     private EmailMessageContent getMessageContent(Object content, String mimeType) throws IOException, MessagingException {
@@ -546,12 +506,9 @@ public final class JavamailAccountDaoImpl implements IMailAccountDao {
                 if (result != null) {
                     return result;
                 }
-
             }
         }
-
         return null;
-
     }
 
     /**
@@ -734,4 +691,36 @@ public final class JavamailAccountDaoImpl implements IMailAccountDao {
     	}
     	return null;
     }
+    
+    private String getTo(Message message) throws MessagingException {
+        Address[] toRecipients = message.getRecipients(RecipientType.TO);
+        return getFormattedAddresses(toRecipients);
+    }
+    
+    private String getCc(Message message) throws MessagingException {
+        Address[] ccRecipients = message.getRecipients(RecipientType.CC);
+        return getFormattedAddresses(ccRecipients);
+    }
+    
+    private String getBcc(Message message) throws MessagingException {
+        Address[] bccRecipients = message.getRecipients(RecipientType.BCC);
+        return getFormattedAddresses(bccRecipients);
+    }
+
+	private String getFormattedAddresses(Address[] addresses) {
+		List <String> recipientsList = new ArrayList <String>();
+        String receiver = null;
+        if (addresses != null && addresses.length != 0) {
+            for (Address adress : addresses){
+                if (INTERNET_ADDRESS_TYPE.equals(adress.getType())) {
+                    InternetAddress inet = (InternetAddress) adress;
+                    receiver = inet.toUnicodeString();
+                } else {
+                    receiver = adress.toString();
+                }          
+                recipientsList.add(receiver);
+            }
+        }
+        return StringUtils.join(recipientsList, "; ").replaceAll("<","&lt;").replaceAll(">","&gt;");
+	}
 }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -124,6 +124,7 @@ preview.message.from=From
 preview.message.subject=Subject
 preview.message.to=To
 preview.message.cc=Cc
+preview.message.bcc=Bcc
 preview.message.date=Date
 preview.message.returnToMessages=Return to messages
 preview.message.delete=Delete

--- a/src/main/webapp/WEB-INF/jsp/mobilePreview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mobilePreview.jsp
@@ -118,11 +118,12 @@
 
     <div class="email-message" style="display:none">
         <ul cellpadding="0" cellspacing="0" class="message-headers">
-            <li><span class="message-header-name"><spring:message code="preview.message.from"/></span><span class="sender"></span></li>
+            <li><span class="message-header-name"><spring:message code="preview.message.from"/></span><span class="from"></span></li>
             <li><span class="message-header-name"><spring:message code="preview.message.subject"/></span><span class="subject"></span></li>
             <li><span class="message-header-name"><spring:message code="preview.message.date"/></span><span class="sentDate"></span></li>
 			<li><span class="message-header-name"><spring:message code="preview.message.to"/></span><span class="toRecipients"></span></li>
-            <li class="ccInfo"><span class="message-header-name"><spring:message code="preview.message.cc"/></span><span class="ccRecipients"></span></li>            
+            <li class="ccInfo"><span class="message-header-name"><spring:message code="preview.message.cc"/></span><span class="ccRecipients"></span></li>
+            <li class="bccInfo"><span class="message-header-name"><spring:message code="preview.message.bcc"/></span><span class="bccRecipients"></span></li>
         </ul>
         <hr/>
 		<p class="pager-msg">        

--- a/src/main/webapp/WEB-INF/jsp/preview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/preview.jsp
@@ -151,11 +151,12 @@
     <c:if test="${allowRenderingEmailContent}">
       <div class="email-message" style="display:none">
           <table cellpadding="0" cellspacing="0" class="message-headers">
-              <tr><td class="message-header-name"><spring:message code="preview.message.from"/></td><td class="sender"></td></tr>
+              <tr><td class="message-header-name"><spring:message code="preview.message.from"/></td><td class="from"></td></tr>
               <tr><td class="message-header-name"><spring:message code="preview.message.subject"/></td><td class="subject"></td></tr>
               <tr><td class="message-header-name"><spring:message code="preview.message.date"/></td><td class="sentDate"></td></tr>
 			  <tr><td class="message-header-name"><spring:message code="preview.message.to"/></td><td class="toRecipients"></td></tr>
-              <tr class="ccInfo"><td class="message-header-name"><spring:message code="preview.message.cc"/></td><td class="ccRecipients"></td></tr>              
+              <tr class="ccInfo"><td class="message-header-name"><spring:message code="preview.message.cc"/></td><td class="ccRecipients"></td></tr>
+              <tr class="bccInfo"><td class="message-header-name"><spring:message code="preview.message.bcc"/></td><td class="bccRecipients"></td></tr>
           </table>
           <hr/>
 		  <span class="previous-msg"><a href="javascript:;">&lt; <spring:message code="preview.pager.previous"/></a></span>

--- a/src/main/webapp/js/email-browser.js
+++ b/src/main/webapp/js/email-browser.js
@@ -41,16 +41,21 @@ var jasig = jasig || {};
         var html = message.content.html ? message.content.contentString : "<pre>" + message.content.contentString + "</pre>";
         that.container.find(".message-content").html(html);
         that.container.find(".email-message .subject").html(message.subject);
-		that.container.find(".email-message .sender").html(message.sender.replace("<","&lt;").replace(">","&gt;"));
+		that.container.find(".email-message .from").html(message.sender);
         that.container.find(".email-message .sentDate").html(message.sentDateString);
     	that.container.find(".email-message .toRecipients").html(message.toRecipients);
-    	that.container.find(".email-message .ccRecipients").html(message.ccRecipients);	
-    	that.container.find(".email-message .ccInfo").show();
-    	if(that.container.find(".email-message .ccRecipients").text() == ""){
-    		that.container.find(".email-message .ccInfo").hide();
+    	that.container.find(".email-message .ccRecipients").html(message.ccRecipients);
+    	that.container.find(".email-message .bccRecipients").html(message.bccRecipients);
+    	
+    	if (that.container.find(".email-message .bccRecipients").text() == ""){
+    		that.container.find(".email-message .bccInfo").hide();
+    	} else {
+    		that.container.find(".email-message .bccInfo").show();
     	}
+
         that.container.find(".email-message .message-uid").val(message.messageId);
 
+        
         // Mark messages read?
         if (that.options.markMessagesAsRead || !message.unread) {
             that.locate("markMessageReadButton").hide();
@@ -322,7 +327,7 @@ var jasig = jasig || {};
                                 ]
                             }
                         }
-                }
+                    }
                 ],
                 bodyRenderer: {
                     type: "fluid.pager.selfRender",
@@ -550,6 +555,7 @@ var jasig = jasig || {};
             emailQuotaUsage: ".email-quota-usage",
             emailQuotaLimit: ".email-quota-limit",
             stats: ".stats",
+            bccRecipients: ".bcc-recipients",
             ccRecipients: ".cc-recipients",
             toRecipients: ".to-recipients",
             previousMsg: ".previous-msg",


### PR DESCRIPTION
- Updating to change email preview to display the 'cc' always and 'bcc' if it exists when displaying a message in both preview and mobilePreview.
- Perf improvement of removing the getAllRecipients call in the wrap email method
- The getting of to, cc and bcc is done only when individual emails are being looked at
- Adding the cc tag class back into the jsps
- Moving getTo, getCc, getBcc to wrap email method
- Adjusting javamail impl to use the same address formatting method
- Adjusting the formatting in ews to match javamail
- Differentiating from and sender classes in jsps
- Sender is the sender name without the email (shown in list of emails)
- From is sender name &lt;email@email.com&gt; format in the email preview
- Removed the binding of the email preview from the account summary and bind manually
- This had the side effect of not calling the account summary everytime
