### PR TITLE
EMAILPLT-153

### DIFF
--- a/src/main/java/org/jasig/portlet/emailpreview/controller/EditPreferencesController.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/controller/EditPreferencesController.java
@@ -240,7 +240,11 @@ public final class EditPreferencesController extends BaseEmailController {
             if (log.isDebugEnabled()) {
                 log.debug("Receieved the following user input for markMessagesAsRead:  '" + markMessagesAsRead + "'");
             }
-            form.setMarkMessagesAsRead(Boolean.valueOf(markMessagesAsRead));
+            if (markMessagesAsRead != null && markMessagesAsRead.equalsIgnoreCase("on")) {
+                form.setMarkMessagesAsRead(true);
+            } else {
+                form.setMarkMessagesAsRead(false);
+            }
         }
         
         if (!config.isReadOnly(req, MailPreferences.INBOX_NAME)) {

--- a/src/main/java/org/jasig/portlet/emailpreview/dao/javamail/JavamailAccountDaoImpl.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/dao/javamail/JavamailAccountDaoImpl.java
@@ -639,10 +639,11 @@ public final class JavamailAccountDaoImpl implements IMailAccountDao {
             Session session = openMailSession(config, auth);
             inbox = getUserInbox(session, config.getInboxFolderName());
 
-            // Verify that we can even perform this operation
+            // Verify that we can even perform this operation log info if it isn't capable of operation
             if (!(inbox instanceof UIDFolder)) {
                 String msg = "Toggle unread feature is supported only for UIDFolder instances";
-                throw new UnsupportedOperationException(msg);
+                log.info(msg);
+                return false;
             }
 
             inbox.open(Folder.READ_WRITE);

--- a/src/main/webapp/WEB-INF/jsp/editPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editPreferences.jsp
@@ -75,7 +75,14 @@
         </c:if>
         <div class="plt-email-row">
             <label><spring:message code="editPreferences.preferences.markMessagesAsRead"/></label>
-            <input type="checkbox" name="markMessagesAsRead" id="plt-email-input-markMessagesAsRead" title="<spring:message code="editPreferences.preferences.markMessagesAsRead.tooltip"/>" value="true"<c:if test="${form.markMessagesAsRead}"> checked="checked"</c:if>/>
+            <c:choose>
+                <c:when test="${form.protocol eq 'pop3' || form.protocol eq 'pop3s'}">
+                    <input type="checkbox" name="markMessagesAsRead" id="plt-email-input-markMessagesAsRead" title="<spring:message code="editPreferences.preferences.markMessagesAsRead.tooltip"/>" disabled/>
+                </c:when>
+                <c:otherwise>
+                    <input type="checkbox" name="markMessagesAsRead" id="plt-email-input-markMessagesAsRead" title="<spring:message code="editPreferences.preferences.markMessagesAsRead.tooltip"/>" <c:if test="${form.markMessagesAsRead}">checked="checked"</c:if>/>
+                </c:otherwise>
+            </c:choose>
         </div>
     </div>          
 
@@ -210,7 +217,15 @@
                 $(that.options.selectors.authtype_preferences).click(function() {
                     $(that.options.selectors.fieldset_preferences).slideDown(400);
                 });
-                
+                $(that.options.selectors.email_input_protocol).change(function() {
+                    if($(that.options.selectors.email_input_protocol).val() == 'pop3' || $(that.options.selectors.email_input_protocol).val() == 'pop3s') {
+                        $(that.options.selectors.email_input_markMessagesAsRead).prop('checked', false);
+                        $(that.options.selectors.email_input_markMessagesAsRead).attr("disabled", true);
+                    } else {
+                        $(that.options.selectors.email_input_markMessagesAsRead).prop('checked', true);
+                        $(that.options.selectors.email_input_markMessagesAsRead).attr("disabled", false);
+                    }
+                });
             };//end:function
             
             var validateForm = function (){
@@ -307,6 +322,8 @@
                 submission_error: "#plt-email-submission-error",
                 authtype_cache: "#authtype_cache",
                 authtype_preferences: "#authtype_preferences",
+                email_input_protocol: "#plt-email-input-protocol",
+                email_input_markMessagesAsRead: "#plt-email-input-markMessagesAsRead",
                 fieldset_preferences: ".plt-email-fieldset-ppauth"
             },
             disableProtocol: false,


### PR DESCRIPTION
- Updating the editPreferences page to only allow mark as read when the protocol is not pop3 or pop3s
  -- Handles both on entry and on editing of the protocol select dropdown
- Updating the preferences controller to handle "on" as true and null to be false
- Updating the mark as read method in JavamailAccountDaoImpl to not bomb out altogether if the protocol doesn't handle the mark as read functionality(with the above fix it should not happen)
  -- it logs at info level that the protocol does not accept this function and returns false
