### PR TITLE
NOJIRA: Fix null sender or subject

### DIFF
--- a/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
@@ -64,8 +64,6 @@ public class EmailMessage {
 	    // Instance Members.
         this.messageNumber = messageNumber;
         this.uid = uid;  // NB:  may be null
-        this.sender = sender;
-        this.subject = subject;
         this.sentDate = sentDate;  // NB:  possibly null in some circumstances
         this.unread = unread;
         this.answered = answered;
@@ -75,6 +73,19 @@ public class EmailMessage {
         this.content = content;
         this.allRecipients = allRecipients;
 	    
+        // sender can be null
+        if (this.sender == null) {
+        	this.sender = "-";
+        } else {
+        	this.sender = sender;
+        }
+        
+        // subject can be null
+        if (this.subject == null) {
+        	this.subject = "-";
+        } else {
+        	this.subject = subject;
+        }
 	}
 
     public EmailMessage(int messageNumber, String uid, String sender, String subject,

--- a/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
@@ -64,6 +64,7 @@ public class EmailMessage {
 	    // Instance Members.
         this.messageNumber = messageNumber;
         this.uid = uid;  // NB:  may be null
+        this.subject = subject;
         this.sentDate = sentDate;  // NB:  possibly null in some circumstances
         this.unread = unread;
         this.answered = answered;
@@ -79,13 +80,7 @@ public class EmailMessage {
         } else {
         	this.sender = sender;
         }
-        
-        // subject can be null
-        if (subject == null) {
-        	this.subject = "-";
-        } else {
-        	this.subject = subject;
-        }
+
 	}
 
     public EmailMessage(int messageNumber, String uid, String sender, String subject,

--- a/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
+++ b/src/main/java/org/jasig/portlet/emailpreview/EmailMessage.java
@@ -74,14 +74,14 @@ public class EmailMessage {
         this.allRecipients = allRecipients;
 	    
         // sender can be null
-        if (this.sender == null) {
+        if (sender == null) {
         	this.sender = "-";
         } else {
         	this.sender = sender;
         }
         
         // subject can be null
-        if (this.subject == null) {
+        if (subject == null) {
         	this.subject = "-";
         } else {
         	this.subject = subject;


### PR DESCRIPTION
In some cases, if an email sender is null (wich can be the case if the email is a test email sent via telnet for example),  a NPE is thrown by method getSenderName() in org.jasig.portlet.emailpreview.EmailMessage class. Fix the problem by replacing a null value by "-" String for Sender. Maybe a localized message "no sender" or "no subject" will be a more appropriate fix. A null subject is displayed "null" in the application.