### PR TITLE
NOJIRA: fix 'duplicate class error' during mvn test

### DIFF
--- a/src/test/java/org/jasig/portlet/emailpreview/util/MessageUtilsTestJ.java
+++ b/src/test/java/org/jasig/portlet/emailpreview/util/MessageUtilsTestJ.java
@@ -11,7 +11,7 @@ import org.junit.Test;
  * @author GIP RECIA 2013 - Maxime BOSSARD.
  *
  */
-public class MessageUtilsTest {
+public class MessageUtilsTestJ {
 
 	private static final String MESSAGE_BODY_WITHOUD_TARGET = "<html><head>" +
 			"<link rel=\"shortcut icon\" href=\"/sites/all/themes/jasig3/favicon.ico\" type=\"image/x-icon\">" +


### PR DESCRIPTION
Fix bug during mvn test phase (since PR #50)

[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /tmp/email-preview/src/test/java/org/jasig/portlet/emailpreview/util/MessageUtilsTest.java:[14,7] duplicate class: org.jasig.portlet.emailpreview.util.MessageUtilsTest
