### PR TITLE
Remove alert(error) from email-browser.js

### DIFF
--- a/src/main/webapp/js/email-browser.js
+++ b/src/main/webapp/js/email-browser.js
@@ -447,9 +447,6 @@ var jasig = jasig || {};
 		                select.find("option[value='INBOX']").css("color","red").css("font-weight","bold");
 		                select.find("option[value='inbox']").css("color","red").css("font-weight","bold");		                
 		                console.log("list completed");
-	                },
-	                error: function(e){
-	                    alert('Error: ' + e);
 	                }
 	            };
 	    		$.ajax(ajaxOptions);


### PR DESCRIPTION
A few things here:
 - Firstly, you shouldn't be showing generic error messsages to end users
 - Secondly, alerting an error object always returns "Error: [Object object]" which isn't helpful even to developers, at least put that in console.log where it can be explained.
 - Thirdly, jQuery throws an AJAX error whenever the request is aborted. So if the user navigates away (clicks a link, presses the back button) before the request completes, they'll get an error message effectively interrupting their departure.